### PR TITLE
Add getPassportInstance as type for return value

### DIFF
--- a/lib/passport/passport.strategy.ts
+++ b/lib/passport/passport.strategy.ts
@@ -5,7 +5,7 @@ export function PassportStrategy<T extends Type<any> = any>(
   Strategy: T,
   name?: string | undefined
 ): {
-  new (...args): InstanceType<T>;
+  new (...args): InstanceType<T> & { getPassportInstance(): passport.PassportStatic };
 } {
   abstract class MixinStrategy extends Strategy {
     abstract validate(...args: any[]): any;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

Add getPassportInstance type for strategy instance value

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

currently you cant use getPassportInstance with typescript without casting "this" into any or similar.

Issue Number: N/A


## What is the new behavior?

function is usable without casting

## Does this PR introduce a breaking change?
- [ ] Yes
- [x ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
